### PR TITLE
Align output size with number of channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ uint64_t Resample_f32(const float *input, float *output, int inSampleRate, int o
     if (input == NULL)
         return 0;
     uint64_t outputSize = (uint64_t) (inputSize * (double) outSampleRate / (double) inSampleRate);
+    outputSize -= outputSize % channels;
     if (output == NULL)
         return outputSize;
     double stepDist = ((double) inSampleRate / (double) outSampleRate);
@@ -39,6 +40,7 @@ uint64_t Resample_s16(const int16_t *input, int16_t *output, int inSampleRate, i
     if (input == NULL)
         return 0;
     uint64_t outputSize = (uint64_t) (inputSize * (double) outSampleRate / (double) inSampleRate);
+    outputSize -= outputSize % channels;
     if (output == NULL)
         return outputSize;
     double stepDist = ((double) inSampleRate / (double) outSampleRate);

--- a/main.c
+++ b/main.c
@@ -104,6 +104,7 @@ uint64_t Resample_f32(const float *input, float *output, int inSampleRate, int o
     if (input == NULL)
         return 0;
     uint64_t outputSize = (uint64_t) (inputSize * (double) outSampleRate / (double) inSampleRate);
+    outputSize -= outputSize % channels;
     if (output == NULL)
         return outputSize;
     double stepDist = ((double) inSampleRate / (double) outSampleRate);
@@ -132,6 +133,7 @@ uint64_t Resample_s16(const int16_t *input, int16_t *output, int inSampleRate, i
     if (input == NULL)
         return 0;
     uint64_t outputSize = (uint64_t) (inputSize * (double) outSampleRate / (double) inSampleRate);
+    outputSize -= outputSize % channels;
     if (output == NULL)
         return outputSize;
     double stepDist = ((double) inSampleRate / (double) outSampleRate);


### PR DESCRIPTION
This pull request ensures that output sizes divide evenly with the number of channels. When resampling dynamically with arbitrary input rates from audio being generated in real time, output sizes that are not aligned with the number of channels will cause scratching and/or clicks. This simply reduces the output size to something that is evenly divisible.