### PR TITLE
fix oob read

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ uint64_t Resample_f32(const float *input, float *output, int inSampleRate, int o
         return 0;
     uint64_t outputSize = (uint64_t) (inputSize * (double) outSampleRate / (double) inSampleRate);
     outputSize -= outputSize % channels;
+    outputSize -= outputSize % 2;
     if (output == NULL)
         return outputSize;
     double stepDist = ((double) inSampleRate / (double) outSampleRate);

--- a/main.c
+++ b/main.c
@@ -105,6 +105,7 @@ uint64_t Resample_f32(const float *input, float *output, int inSampleRate, int o
         return 0;
     uint64_t outputSize = (uint64_t) (inputSize * (double) outSampleRate / (double) inSampleRate);
     outputSize -= outputSize % channels;
+    outputSize -= outputSize % 2;
     if (output == NULL)
         return outputSize;
     double stepDist = ((double) inSampleRate / (double) outSampleRate);


### PR DESCRIPTION
fix out-of-bounds read (and garbage last field) when outputSize % 2 == 1

demonstration
```c
int16_t input_buffer[1024];
for (int i = 0; i < 1024; i++) {
  input_buffer[i] = i * 10;
}
size_t input_size = sizeof(input_buffer) / sizeof(input_buffer[0]);

// zeroes for demonstration purposes
int16_t output_buffer[4096];
for (int i = 0; i < 4096; i++) {
  output_buffer[i] = 0;
}

size_t output_size = Resample_s16(input_buffer, output_buffer, 8000, 11025, 1024, 1);

printf("Original Data (%u):\n", input_size);
for (size_t i = 0; i < 1024; i++) {
  printf("%hd ", input_buffer[i]);
}

printf("\nUpsampled Data (%u):\n", output_size);
for (size_t i = 0; i < output_size; i++) {
  printf("%hd ", output_buffer[i]);
}
printf("\nLast field garbage data: output_buffer[%u]=%u\n", output_size-1, output_buffer[output_size-1]);
```
